### PR TITLE
more args types

### DIFF
--- a/src/epipe.erl
+++ b/src/epipe.erl
@@ -13,15 +13,23 @@
       InitialState :: term(),
       PipeFun      :: fun((SomeState :: term()) -> PipeFunRes),
       PipeFunRes   :: {ok, NextState :: term()}
+                    | {stop, State :: term()}
                     | {error, Reason :: term()}
                     | {error, Reason :: term(), NewState :: term()},
       Result       :: {ok, State :: term()}
+                    | {ok, Label, State :: term()}
+                    | {stop, Label, State::term()}
                     | {error, Label, Reason :: term(), NewState :: term()}.
+
 run([], State) ->
     {ok, State};
+run(FuncList, State) when erlang:is_tuple(State) ->
+    run(FuncList, erlang:tuple_to_list(State));
 run([{Label, Func} | Rest], State) ->
-    case Func(State) of
+    case erlang:apply(Func, State) of
+        ok                        -> {ok, Label, State};
         {ok, NewState}            -> run(Rest, NewState);
+        {stop, NewState}          -> {stop, Label, NewState};
         {error, Reason}           -> {error, Label, Reason, State};
         {error, Reason, NewState} -> {error, Label, Reason, NewState}
     end.

--- a/src/epipe.erl
+++ b/src/epipe.erl
@@ -25,6 +25,8 @@ run([], State) ->
     {ok, State};
 run(FuncList, State) when erlang:is_tuple(State) ->
     run(FuncList, erlang:tuple_to_list(State));
+run(FuncList, State) when not erlang:is_list(State) ->
+    run(FuncList, [State]);
 run([{Label, Func} | Rest], State) ->
     case erlang:apply(Func, State) of
         ok                        -> {ok, Label, State};


### PR DESCRIPTION
I tried to modify the operation mode into a multivariable type and added a case to drop off

eg:
Fun1 = fun(Val) -> {ok, [Val, Val]} end,
Fun2 = fun(Val, Sum) -> {ok, Sum + Val} end,
epipe:run([{f1, Fun1}, {f2, Fun2}], 1).

or pipe fun can  fun module:function/n 